### PR TITLE
Moving the welcome func/handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,8 +16,10 @@ limitations under the License.
 package main
 
 import (
+	"net/http"
 	"os"
 
+	"github.com/gin-gonic/gin"
 	fhirSvr "github.com/intervention-engine/fhir/server"
 	"github.com/mitre/ptmatch/server"
 )
@@ -32,5 +34,10 @@ func main() {
 	s := fhirSvr.NewServer(mongoHost)
 	server.Setup(s)
 
+	s.Engine.GET("/", welcome)
 	s.Run(fhirSvr.Config{})
+}
+
+func welcome(c *gin.Context) {
+	c.String(http.StatusOK, "Patient Matching Test Harness Server")
 }

--- a/server/server_setup.go
+++ b/server/server_setup.go
@@ -72,8 +72,6 @@ func registerMiddleware(svr *fhir_svr.FHIRServer) {
 }
 
 func registerRoutes(svr *fhir_svr.FHIRServer) {
-	svr.Engine.GET("/", welcome)
-
 	controller := rc.ResourceController{}
 	controller.DatabaseProvider = Database
 
@@ -94,8 +92,4 @@ func registerRoutes(svr *fhir_svr.FHIRServer) {
 	svr.Engine.POST("/"+name, controller.CreateRecordMatchJob)
 	svr.Engine.PUT("/"+name+"/:id", controller.UpdateResource)
 	svr.Engine.DELETE("/"+name+"/:id", controller.DeleteResource)
-}
-
-func welcome(c *gin.Context) {
-	c.String(http.StatusOK, "Patient Matching Test Harness Server")
 }


### PR DESCRIPTION
The welcome function gets set up on the root of the web application. That is
fine if this is being run as a stand alone application. If it is being
incorporated into another application. This moves the function and handler into
the main, so it won't be present when used as a library.
