### PR TITLE
Simple implementation of search

### DIFF
--- a/fixtures/record-match-run-02.json
+++ b/fixtures/record-match-run-02.json
@@ -1,0 +1,6 @@
+{
+  "recordMatchContextId": "575f0aefa749dce155e7c3b0",
+  "matchingMode" : "deduplication",
+  "masterRecordSetId": "569408c1a291020e5b3636f4",
+  "recordMatchSystemInterfaceId": "569408c1a291020e5b3637a4"
+}


### PR DESCRIPTION
This code is the start of an implementation of search for resources specific to
the patient matching test harness. The current code allows for search against
RecordMatchRuns by recordMatchContextId. It is possible to extend this
implementation by adding to the SearchParams variable in controllers.

The current implementation infers the type of the search parameter by name. If
the name ends in "Id", it assumes that the type should be bson.ObjectId.
Otherwise, it is a string.
