### PR TITLE
Links services

### DIFF
--- a/controllers/record_match_run.go
+++ b/controllers/record_match_run.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/Sirupsen/logrus"
@@ -35,104 +36,157 @@ import (
 	ptm_models "github.com/mitre/ptmatch/models"
 )
 
-// CreateRecordMatchRun creates a new Record Match Run and constructs and
-// sends a Record Match request message.
-func (rc *ResourceController) CreateRecordMatchRun(ctx *gin.Context) {
-	req := ctx.Request
-	resourceType := getResourceType(req.URL)
-	obj := ptm_models.NewStructForResourceName(resourceType)
-	recMatchRun := obj.(*ptm_models.RecordMatchRun)
-	if err := ctx.Bind(recMatchRun); err != nil {
-		ctx.AbortWithError(http.StatusInternalServerError, err)
-		return
-	}
+// CreateRecordMatchRunHandler creates a HandlerFunc that creates a new
+// RecordMatchRun and constructs and sends a Record Match request message.
+func CreateRecordMatchRunHandler(db *mgo.Database) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		recMatchRun := &ptm_models.RecordMatchRun{}
+		if err := ctx.Bind(recMatchRun); err != nil {
+			ctx.AbortWithError(http.StatusInternalServerError, err)
+			return
+		}
 
-	if !isValidRecordMatchRun(recMatchRun) {
-		// Bad Request: Record Match Run contains invalid content
-		ctx.String(http.StatusBadRequest, "Invalid RecordMatchRun content")
-		ctx.Abort()
-		return
-	}
+		if !isValidRecordMatchRun(recMatchRun) {
+			// Bad Request: Record Match Run contains invalid content
+			ctx.String(http.StatusBadRequest, "Invalid RecordMatchRun content")
+			ctx.Abort()
+			return
+		}
 
-	// retrieve and validate the record match context
-	recMatchContextID := recMatchRun.RecordMatchContextID
-	logger.Log.WithFields(
-		logrus.Fields{"method": "CreateRecordMatchRun",
-			"recMatchContextID": recMatchContextID}).Debug("check recmatch config id")
-	if !recMatchContextID.Valid() {
-		// Bad Request: Record Match Context is optional but must be valid, if provided
-		ctx.String(http.StatusBadRequest, "Invalid RecordMatchContextID")
-		ctx.Abort()
-		return
-	}
-
-	// Retrieve the info about the record matcher
-	obj, err := ptm_models.LoadResource(rc.Database(), "RecordMatchSystemInterface",
-		recMatchRun.RecordMatchSystemInterfaceID)
-	if err != nil {
-		ctx.String(http.StatusBadRequest, "Unable to find Record Match System Interface")
-		ctx.Abort()
-		return
-	}
-	recMatchSysIface := obj.(*ptm_models.RecordMatchSystemInterface)
-	if !isValidRecordMatchSysIface(recMatchSysIface) {
-		ctx.String(http.StatusBadRequest, "Invalid Record Match System Interface")
-		ctx.Abort()
-		return
-	}
-
-	// construct a record match request
-	reqMatchRequest := rc.newRecordMatchRequest(recMatchSysIface.ResponseEndpoint, recMatchRun)
-	// attach the request message to the run object
-	recMatchRun.Request = *reqMatchRequest
-
-	// Construct body of the http request for the record match request
-	reqBody, _ := reqMatchRequest.Message.MarshalJSON()
-
-	svrEndpoint := prepEndpoint(recMatchSysIface.ServerEndpoint, reqMatchRequest.Message.Id)
-
-	logger.Log.WithFields(
-		logrus.Fields{"method": "CreateRecordMatchRun",
-			"server endpoint": svrEndpoint,
-			"reqBody":         string(reqBody[:]),
-			"message":         reqMatchRequest.Message,
-			"request":         reqMatchRequest}).Info("About to submit request")
-
-	reqMatchRequest.SubmittedOn = time.Now()
-	// submit the record match request
-	resp, err := ptm_http.Put(svrEndpoint, "application/json+fhir",
-		bytes.NewReader(reqBody))
-	if err != nil {
+		// retrieve and validate the record match context
+		recMatchContextID := recMatchRun.RecordMatchContextID
 		logger.Log.WithFields(
 			logrus.Fields{"method": "CreateRecordMatchRun",
-				"err": err}).Error("Sending Record Match Request")
-		ctx.AbortWithError(http.StatusInternalServerError, err)
-		return
-	}
+				"recMatchContextID": recMatchContextID}).Debug("check recmatch config id")
+		if !recMatchContextID.Valid() {
+			// Bad Request: Record Match Context is optional but must be valid, if provided
+			ctx.String(http.StatusBadRequest, "Invalid RecordMatchContextID")
+			ctx.Abort()
+			return
+		}
 
-	// Store status, Sent, with the run object
-	recMatchRun.Status = make([]ptm_models.RecordMatchRunStatusComponent, 1)
-	recMatchRun.Status[0].CreatedOn = time.Now()
-	// if a success code was received
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		recMatchRun.Status[0].Message = "Request Sent [" + resp.Status + "]"
-	} else {
-		recMatchRun.Status[0].Message = "Error Sending Request to Record Matcher [" + resp.Status + "]"
-	}
+		// Retrieve the info about the record matcher
+		obj, err := ptm_models.LoadResource(db, "RecordMatchSystemInterface",
+			recMatchRun.RecordMatchSystemInterfaceID)
+		if err != nil {
+			ctx.String(http.StatusBadRequest, "Unable to find Record Match System Interface")
+			ctx.Abort()
+			return
+		}
+		recMatchSysIface := obj.(*ptm_models.RecordMatchSystemInterface)
+		if !isValidRecordMatchSysIface(recMatchSysIface) {
+			ctx.String(http.StatusBadRequest, "Invalid Record Match System Interface")
+			ctx.Abort()
+			return
+		}
 
-	// Persist the record match run
-	resource, err := ptm_models.PersistResource(rc.Database(), resourceType, recMatchRun)
-	if err != nil {
-		ctx.AbortWithError(http.StatusInternalServerError, err)
-		return
-	}
+		// construct a record match request
+		reqMatchRequest := newRecordMatchRequest(recMatchSysIface.ResponseEndpoint, recMatchRun, db)
+		// attach the request message to the run object
+		recMatchRun.Request = *reqMatchRequest
 
-	/*
+		// Construct body of the http request for the record match request
+		reqBody, _ := reqMatchRequest.Message.MarshalJSON()
+
+		svrEndpoint := prepEndpoint(recMatchSysIface.ServerEndpoint, reqMatchRequest.Message.Id)
+
 		logger.Log.WithFields(
-			logrus.Fields{"collection": ptm_models.GetCollectionName(resourceType),
-				"res type": resourceType, "id": id}).Info("CreateResource")
-	*/
-	ctx.JSON(http.StatusCreated, resource)
+			logrus.Fields{"method": "CreateRecordMatchRun",
+				"server endpoint": svrEndpoint,
+				"reqBody":         string(reqBody[:]),
+				"message":         reqMatchRequest.Message,
+				"request":         reqMatchRequest}).Info("About to submit request")
+
+		reqMatchRequest.SubmittedOn = time.Now()
+		// submit the record match request
+		resp, err := ptm_http.Put(svrEndpoint, "application/json+fhir",
+			bytes.NewReader(reqBody))
+		if err != nil {
+			logger.Log.WithFields(
+				logrus.Fields{"method": "CreateRecordMatchRun",
+					"err": err}).Error("Sending Record Match Request")
+			ctx.AbortWithError(http.StatusInternalServerError, err)
+			return
+		}
+
+		// Store status, Sent, with the run object
+		recMatchRun.Status = make([]ptm_models.RecordMatchRunStatusComponent, 1)
+		recMatchRun.Status[0].CreatedOn = time.Now()
+		// if a success code was received
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			recMatchRun.Status[0].Message = "Request Sent [" + resp.Status + "]"
+		} else {
+			recMatchRun.Status[0].Message = "Error Sending Request to Record Matcher [" + resp.Status + "]"
+		}
+
+		// Persist the record match run
+		resource, err := ptm_models.PersistResource(db, "RecordMatchRun", recMatchRun)
+		if err != nil {
+			ctx.AbortWithError(http.StatusInternalServerError, err)
+			return
+		}
+
+		/*
+			logger.Log.WithFields(
+				logrus.Fields{"collection": ptm_models.GetCollectionName(resourceType),
+					"res type": resourceType, "id": id}).Info("CreateResource")
+		*/
+		ctx.JSON(http.StatusCreated, resource)
+	}
+}
+
+func GetRecordMatchRunMetricsHandler(db *mgo.Database) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		resourceType := "RecordMatchRun"
+
+		recordMatchSystemInterfaceId := ctx.Query("recordMatchSystemInterfaceId")
+		validRecordMatchSystemInterfaceId := len(recordMatchSystemInterfaceId) > 1 && len(recordMatchSystemInterfaceId) <= 24 && bson.IsObjectIdHex(recordMatchSystemInterfaceId)
+		recordSetId := ctx.Query("recordSetId")
+		validRecordSetId := len(recordSetId) > 1 && len(recordSetId) <= 24 && bson.IsObjectIdHex(recordSetId)
+
+		logger.Log.WithFields(
+			logrus.Fields{"resource type": resourceType, "rec match sys": recordMatchSystemInterfaceId, "record set": recordSetId}).Info("GetRecordMatchRunMetrics")
+
+		resources := ptm_models.NewSliceForResourceName(resourceType, 0, 0)
+		c := db.C(ptm_models.GetCollectionName(resourceType))
+
+		var query *mgo.Query
+
+		if validRecordSetId {
+			logger.Log.WithFields(
+				// find the record match runs with masterRecordSetId or queryRecordSetId == record set id
+				logrus.Fields{"validRecord Set Id": validRecordSetId, "record set": recordSetId}).Info("GetRecordMatchRunMetrics")
+
+			recordSetBsonId, _ := ptm_models.ToBsonObjectID(recordSetId)
+			query = c.Find(bson.M{"$or": []bson.M{bson.M{"masterRecordSetId": recordSetBsonId}, bson.M{"queryRecordSetId": recordSetBsonId}}})
+
+		} else if validRecordMatchSystemInterfaceId {
+			recordMatchSystemInterfaceBsonId, _ := ptm_models.ToBsonObjectID(recordMatchSystemInterfaceId)
+			query = c.Find(bson.M{"recordMatchSystemInterfaceId": recordMatchSystemInterfaceBsonId})
+
+		} else { // no query parameters were provided
+			// get all record runs with, primarily, metrics only
+			// retrieve all documents in the collection
+			// TODO Restrict this to resourc type, just to be extra safe
+			query = c.Find(bson.M{})
+		}
+
+		// constrain which fields are returned
+		err := query.Select(bson.M{"meta": 1, "metrics": 1, "recordMatchSystemInterfaceId": 1, "matchingMode": 1, "recordResourceType": 1, "masterRecordSetId": 1, "queryRecordSetId": 1, "recordMatchContextId": 1}).All(resources)
+
+		if err != nil {
+			if err == mgo.ErrNotFound {
+				ctx.String(http.StatusNotFound, "Not Found")
+				ctx.Abort()
+				return
+			} else {
+				ctx.AbortWithError(http.StatusBadRequest, err)
+				return
+			}
+		}
+
+		ctx.JSON(http.StatusOK, resources)
+	}
 }
 
 func isValidRecordMatchRun(rmr *ptm_models.RecordMatchRun) bool {
@@ -186,8 +240,8 @@ func prepEndpoint(baseURL, id string) string {
 	return result
 }
 
-func (rc *ResourceController) newRecordMatchRequest(srcEndpoint string,
-	recMatchRun *ptm_models.RecordMatchRun) *ptm_models.RecordMatchRequest {
+func newRecordMatchRequest(srcEndpoint string,
+	recMatchRun *ptm_models.RecordMatchRun, db *mgo.Database) *ptm_models.RecordMatchRequest {
 
 	req := &ptm_models.RecordMatchRequest{ID: bson.NewObjectId()}
 	req.Message = &fhir_models.Bundle{}
@@ -202,7 +256,7 @@ func (rc *ResourceController) newRecordMatchRequest(srcEndpoint string,
 	}
 	req.Message.Entry = make([]fhir_models.BundleEntryComponent, numEntries)
 
-	msgHdr, err := rc.newMessageHeader(srcEndpoint, recMatchRun)
+	msgHdr, err := newMessageHeader(srcEndpoint, recMatchRun, db)
 	if err != nil {
 		//TODO What should I do here?  panic?
 		panic(fmt.Sprintf("Not IMPL: New Msg Hdr returned error: %s", err.Error()))
@@ -210,7 +264,7 @@ func (rc *ResourceController) newRecordMatchRequest(srcEndpoint string,
 	req.Message.Entry[0].Resource = msgHdr
 	req.Message.Entry[0].FullUrl = "urn:uuid:" + msgHdr.Id
 
-	rc.addRecordSetParams(recMatchRun, req.Message)
+	addRecordSetParams(recMatchRun, req.Message, db)
 	msgHdr.Data = make([]fhir_models.Reference, numEntries-1)
 
 	msgHdr.Data[0].Reference = req.Message.Entry[1].FullUrl
@@ -231,14 +285,14 @@ func (rc *ResourceController) newRecordMatchRequest(srcEndpoint string,
 
 // newMessageHeader constructs a FHIR MessageHeader resource using the information
 // associated with the given RecordMatchRun.
-func (rc *ResourceController) newMessageHeader(
-	srcEndpoint string, recMatchRun *ptm_models.RecordMatchRun) (*fhir_models.MessageHeader, error) {
+func newMessageHeader(
+	srcEndpoint string, recMatchRun *ptm_models.RecordMatchRun, db *mgo.Database) (*fhir_models.MessageHeader, error) {
 	msgHdr := fhir_models.MessageHeader{}
 	msgHdr.Id = uuid.NewV4().String()
 
 	// load the record match system Interface referenced in record match run
 	obj, err := ptm_models.LoadResource(
-		rc.Database(), "RecordMatchSystemInterface", recMatchRun.RecordMatchSystemInterfaceID)
+		db, "RecordMatchSystemInterface", recMatchRun.RecordMatchSystemInterfaceID)
 	if err != nil {
 		return &msgHdr, err
 	}
@@ -266,11 +320,9 @@ func (rc *ResourceController) newMessageHeader(
 	return &msgHdr, nil
 }
 
-func (rc *ResourceController) addRecordSetParams(recMatchRun *ptm_models.RecordMatchRun, msg *fhir_models.Bundle) error {
-
+func addRecordSetParams(recMatchRun *ptm_models.RecordMatchRun, msg *fhir_models.Bundle, db *mgo.Database) error {
 	// retrieve the info for the master record Set
-	obj, err := ptm_models.LoadResource(
-		rc.Database(), "RecordSet", recMatchRun.MasterRecordSetID)
+	obj, err := ptm_models.LoadResource(db, "RecordSet", recMatchRun.MasterRecordSetID)
 	if err != nil {
 		return err
 	}
@@ -287,7 +339,7 @@ func (rc *ResourceController) addRecordSetParams(recMatchRun *ptm_models.RecordM
 	if recMatchRun.MatchingMode == ptm_models.Query {
 		// retrieve the info for the query record set
 		obj, err := ptm_models.LoadResource(
-			rc.Database(), "RecordSet", recMatchRun.QueryRecordSetID)
+			db, "RecordSet", recMatchRun.QueryRecordSetID)
 		if err != nil {
 			return err
 		}

--- a/controllers/resource_controller.go
+++ b/controllers/resource_controller.go
@@ -285,58 +285,6 @@ func responseURL(r *http.Request, paths ...string) *url.URL {
 	return &responseURL
 }
 
-func (rc *ResourceController) GetRecordMatchRunMetrics(ctx *gin.Context) {
-	resourceType := "RecordMatchRun"
-
-	recordMatchSystemInterfaceId := ctx.Query("recordMatchSystemInterfaceId")
-	validRecordMatchSystemInterfaceId := len(recordMatchSystemInterfaceId) > 1 && len(recordMatchSystemInterfaceId) <= 24 && bson.IsObjectIdHex(recordMatchSystemInterfaceId)
-	recordSetId := ctx.Query("recordSetId")
-	validRecordSetId := len(recordSetId) > 1 && len(recordSetId) <= 24 && bson.IsObjectIdHex(recordSetId)
-
-	logger.Log.WithFields(
-		logrus.Fields{"resource type": resourceType, "rec match sys": recordMatchSystemInterfaceId, "record set": recordSetId}).Info("GetRecordMatchRunMetrics")
-
-	resources := ptm_models.NewSliceForResourceName(resourceType, 0, 0)
-	c := rc.Database().C(ptm_models.GetCollectionName(resourceType))
-
-	var query *mgo.Query
-
-	if validRecordSetId {
-		logger.Log.WithFields(
-			// find the record match runs with masterRecordSetId or queryRecordSetId == record set id
-			logrus.Fields{"validRecord Set Id": validRecordSetId, "record set": recordSetId}).Info("GetRecordMatchRunMetrics")
-
-		recordSetBsonId, _ := ptm_models.ToBsonObjectID(recordSetId)
-		query = c.Find(bson.M{"$or": []bson.M{bson.M{"masterRecordSetId": recordSetBsonId}, bson.M{"queryRecordSetId": recordSetBsonId}}})
-
-	} else if validRecordMatchSystemInterfaceId {
-		recordMatchSystemInterfaceBsonId, _ := ptm_models.ToBsonObjectID(recordMatchSystemInterfaceId)
-		query = c.Find(bson.M{"recordMatchSystemInterfaceId": recordMatchSystemInterfaceBsonId})
-
-	} else { // no query parameters were provided
-		// get all record runs with, primarily, metrics only
-		// retrieve all documents in the collection
-		// TODO Restrict this to resourc type, just to be extra safe
-		query = c.Find(bson.M{})
-	}
-
-	// constrain which fields are returned
-	err := query.Select(bson.M{"meta": 1, "metrics": 1, "recordMatchSystemInterfaceId": 1, "matchingMode": 1, "recordResourceType": 1, "masterRecordSetId": 1, "queryRecordSetId": 1, "recordMatchContextId": 1}).All(resources)
-
-	if err != nil {
-		if err == mgo.ErrNotFound {
-			ctx.String(http.StatusNotFound, "Not Found")
-			ctx.Abort()
-			return
-		} else {
-			ctx.AbortWithError(http.StatusBadRequest, err)
-			return
-		}
-	}
-
-	ctx.JSON(http.StatusOK, resources)
-}
-
 // SetAnswerKey associates a specified Record Set with a FHIR Bundle that
 // contains a set of expected record matches (i.e., answer key for the record set)
 // The uploaded file is expected to be a FHIR Bundle  of type, document,

--- a/fixtures/record-match-run-responses.json
+++ b/fixtures/record-match-run-responses.json
@@ -1,0 +1,334 @@
+{
+  "id": "576173e95b5b8b9296b3f947",
+  "meta": {
+    "createdOn": "2016-05-12T12:45:11.429-04:00",
+    "lastUpdatedOn": "2016-05-12T12:45:11.429-04:00"
+  },
+  "note": "First run",
+  "recordMatchContextId": "57597a52fb0482af6543f354",
+  "request": {
+    "id": "5734b3173dc37e49116e4edf",
+    "meta": {
+      "createdOn": "2016-05-12T12:45:11.424-04:00",
+      "lastUpdatedOn": "0001-01-01T00:00:00Z"
+    },
+    "message": {
+      "resourceType": "Bundle",
+      "id": "5734b3173dc37e49116e4ee0",
+      "type": "message",
+      "entry": [
+        {
+          "fullUrl": "urn:uuid:a41975cb-c961-4d17-9a06-8c49c95877c2",
+          "resource": {
+            "_id": "a41975cb-c961-4d17-9a06-8c49c95877c2",
+            "data": [
+              {
+                "reference": "urn:uuid:5062ba92-9ceb-467c-9894-8024f5629708"
+              }
+            ],
+            "destination": [
+              {
+                "endpoint": "http://mitre.org/ptmatchadapter-fril",
+                "name": "FRIL - Equal Weight - Accept 60"
+              }
+            ],
+            "event": {
+              "code": "record-match",
+              "system": "http://github.com/mitre/ptmatch/fhir/message-events"
+            },
+            "resourceType": "MessageHeader",
+            "source": {
+              "endpoint": "http://mitre.org/ptmatch"
+            },
+            "timestamp": {
+              "precision": "timestamp",
+              "time": "2016-05-12T12:45:11.42-04:00"
+            }
+          }
+        },
+        {
+          "fullUrl": "urn:uuid:5062ba92-9ceb-467c-9894-8024f5629708",
+          "resource": {
+            "_id": "5062ba92-9ceb-467c-9894-8024f5629708",
+            "parameter": [
+              {
+                "name": "type",
+                "valueString": "master"
+              },
+              {
+                "name": "resourceType",
+                "valueString": "Patient"
+              },
+              {
+                "name": "searchExpression",
+                "resource": {
+                  "parameter": [
+                    {
+                      "name": "resourceUrl",
+                      "valueString": "http://localhost:3001/Patient"
+                    },
+                    {
+                      "name": "gender",
+                      "valueString": "MALE"
+                    }
+                  ],
+                  "resourceType": "Parameters"
+                }
+              }
+            ],
+            "resourceType": "Parameters"
+          }
+        }
+      ]
+    },
+    "submittedOn": "0001-01-01T00:00:00Z"
+  },
+  "responses": [
+    {
+      "id": "5734b343218de24972dabd21",
+      "meta": {
+        "createdOn": "2016-05-12T12:45:55.59-04:00",
+        "lastUpdatedOn": "2016-05-12T12:45:55.59-04:00"
+      },
+      "message": {
+        "resourceType": "Bundle",
+        "id": "5734b343218de24972dabd21",
+        "meta": {
+          "lastUpdated": "2016-05-12T12:45:55-04:00"
+        },
+        "type": "message",
+        "entry": [
+          {
+            "fullUrl": "12dab49b-b8b0-4407-895e-296177856129",
+            "resource": {
+              "_id": "5734b343218de24972dabd22",
+              "destination": [
+                {
+                  "endpoint": "http://mitre.org/ptmatch"
+                }
+              ],
+              "event": {
+                "code": "record-match",
+                "system": "http://github.com/mitre/ptmatch/fhir/message-events"
+              },
+              "resourceType": "MessageHeader",
+              "response": {
+                "code": "ok",
+                "identifier": "a41975cb-c961-4d17-9a06-8c49c95877c2"
+              },
+              "source": {
+                "endpoint": "http://mitre.org/ptmatchadapter-fril",
+                "name": "ptmatchAdapter-fril"
+              },
+              "timestamp": {
+                "precision": "timestamp",
+                "time": "2016-05-12T12:45:55.568-04:00"
+              }
+            }
+          }
+        ]
+      },
+      "receivedOn": "2016-05-12T12:45:55.59-04:00"
+    },
+    {
+      "id": "5734b343218de24972dabd23",
+      "meta": {
+        "createdOn": "2016-05-12T12:45:56.004-04:00",
+        "lastUpdatedOn": "2016-05-12T12:45:56.004-04:00"
+      },
+      "message": {
+        "resourceType": "Bundle",
+        "id": "5734b343218de24972dabd23",
+        "meta": {
+          "lastUpdated": "2016-05-12T12:45:56-04:00"
+        },
+        "type": "message",
+        "entry": [
+          {
+            "fullUrl": "urn:uuid:43869c10-cfc6-47d3-843d-a40c31550685",
+            "resource": {
+              "_id": "5734b343218de24972dabd24",
+              "data": [
+                {
+                  "external": false,
+                  "reference": "urn:uuid:5062ba92-9ceb-467c-9894-8024f5629708"
+                }
+              ],
+              "destination": [
+                {
+                  "endpoint": "http://mitre.org/ptmatch"
+                }
+              ],
+              "event": {
+                "code": "record-match",
+                "system": "http://github.com/mitre/ptmatch/fhir/message-events"
+              },
+              "resourceType": "MessageHeader",
+              "response": {
+                "code": "ok",
+                "identifier": "a41975cb-c961-4d17-9a06-8c49c95877c2"
+              },
+              "source": {
+                "endpoint": "http://mitre.org/ptmatchadapter-fril",
+                "name": "FRIL - Equal Weight - Accept 60"
+              },
+              "timestamp": {
+                "precision": "timestamp",
+                "time": "2016-05-12T12:45:55.977-04:00"
+              }
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:2b4db293-be03-42a1-953b-1a8e1de00468",
+            "resource": {
+              "_id": "5734b343218de24972dabd25",
+              "issue": [
+                {
+                  "code": "informational",
+                  "details": {
+                    "text": "Deduplication Complete"
+                  },
+                  "severity": "information"
+                }
+              ],
+              "resourceType": "OperationOutcome"
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:5062ba92-9ceb-467c-9894-8024f5629708",
+            "resource": {
+              "_id": "5062ba92-9ceb-467c-9894-8024f5629708",
+              "parameter": [
+                {
+                  "name": "type",
+                  "valueString": "master"
+                },
+                {
+                  "name": "resourceType",
+                  "valueString": "Patient"
+                },
+                {
+                  "name": "searchExpression",
+                  "resource": {
+                    "parameter": [
+                      {
+                        "name": "resourceUrl",
+                        "valueString": "http://localhost:3001/Patient"
+                      },
+                      {
+                        "name": "gender",
+                        "valueString": "MALE"
+                      }
+                    ],
+                    "resourceType": "Parameters"
+                  }
+                }
+              ],
+              "resourceType": "Parameters"
+            }
+          },
+          {
+            "link": [
+              {
+                "relation": "type",
+                "url": "http://hl7.org/fhir/Patient"
+              },
+              {
+                "relation": "related",
+                "url": "http://localhost:3001/Patient/57334e7c65ddb4272a7db007"
+              }
+            ],
+            "fullUrl": "http://localhost:3001/Patient/5616b6991cd462440e00020e",
+            "search": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/patient-mpi-match",
+                  "valueCode": "probable"
+                }
+              ],
+              "score": 0.55
+            }
+          },
+          {
+            "link": [
+              {
+                "relation": "type",
+                "url": "http://hl7.org/fhir/Patient"
+              },
+              {
+                "relation": "related",
+                "url": "http://localhost:3001/Patient/57335da265ddb433bd30f0ee"
+              }
+            ],
+            "fullUrl": "http://localhost:3001/Patient/5616b69a1cd462440e0006ae",
+            "search": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/patient-mpi-match",
+                  "valueCode": "probable"
+                }
+              ],
+              "score": 0.82
+            }
+          },
+          {
+            "link": [
+              {
+                "relation": "type",
+                "url": "http://hl7.org/fhir/Patient"
+              },
+              {
+                "relation": "related",
+                "url": "http://localhost:3001/Patient/57335e8465ddb433bd30f0ef"
+              }
+            ],
+            "fullUrl": "http://localhost:3001/Patient/5616b6a11cd462440e001586",
+            "search": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/patient-mpi-match",
+                  "valueCode": "probable"
+                }
+              ],
+              "score": 0.51
+            }
+          }
+        ]
+      },
+      "receivedOn": "2016-05-12T12:45:56.004-04:00"
+    }
+  ],
+  "metrics": {
+    "f1": 0.55,
+    "precision": 0.49,
+    "recall": 0.61,
+    "matchCount": 3,
+    "truePositiveCount": 3
+  },
+  "status": [
+    {
+      "message": "Request Sent [201 Created]",
+      "createdOn": "2016-05-12T12:45:11.429-04:00"
+    },
+    {
+      "message": "Response Received [5734b343218de24972dabd21]",
+      "createdOn": "2016-05-12T12:45:55.59-04:00"
+    },
+    {
+      "message": "Metrics Updated [5734b343218de24972dabd21]",
+      "createdOn": "2016-05-12T12:45:55.594-04:00"
+    },
+    {
+      "message": "Response Received [5734b343218de24972dabd23]",
+      "createdOn": "2016-05-12T12:45:56.004-04:00"
+    },
+    {
+      "message": "Metrics Updated [5734b343218de24972dabd23]",
+      "createdOn": "2016-05-12T12:45:56.009-04:00"
+    }
+  ],
+  "matchingMode": "deduplication",
+  "recordResourceType": "Patient",
+  "recordMatchSystemInterfaceId": "575972f3fb0482af6543f34f",
+  "masterRecordSetId": "57334a0665ddb4272a7db000"
+}

--- a/models/record_match_run.go
+++ b/models/record_match_run.go
@@ -17,6 +17,7 @@ limitations under the License.
 package models
 
 import (
+	"sort"
 	"time"
 
 	"gopkg.in/mgo.v2/bson"
@@ -58,4 +59,50 @@ type RecordMatchRunMetrics struct {
 type RecordMatchRunStatusComponent struct {
 	Message   string    `bson:"message" json:"message"`
 	CreatedOn time.Time `bson:"createdOn,omitempty" json:"createdOn,omitempty"`
+}
+
+// Link is not part of FHIR. It is a simplified representation of a suggested
+// link (or lack thereof) between two records.
+type Link struct {
+	Source string  `json:"source"`
+	Target string  `json:"target"`
+	Match  string  `json:"match"`
+	Score  float64 `json:"score"`
+}
+
+// LinkSlice is needed as a holder for the functions to work with the sort
+// package
+type LinkSlice []Link
+
+func (ls LinkSlice) Len() int           { return len(ls) }
+func (ls LinkSlice) Swap(i, j int)      { ls[i], ls[j] = ls[j], ls[i] }
+func (ls LinkSlice) Less(i, j int) bool { return ls[i].Score < ls[j].Score }
+
+// GetLinks searches all responses to the match run and creates a []Link that is
+// sorted by Score.
+func (rmr *RecordMatchRun) GetLinks() []Link {
+	var links []Link
+	for _, response := range rmr.Responses {
+		for _, entry := range response.Message.Entry {
+			if len(entry.Link) == 2 {
+				source := entry.FullUrl
+				var target string
+				for _, l := range entry.Link {
+					if l.Relation == "related" {
+						target = l.Url
+					}
+				}
+				var match string
+				for _, e := range entry.Search.Extension {
+					if e.Url == "http://hl7.org/fhir/StructureDefinition/patient-mpi-match" {
+						match = e.ValueCode
+					}
+				}
+				score := *entry.Search.Score
+				links = append(links, Link{source, target, match, score})
+			}
+		}
+	}
+	sort.Sort(LinkSlice(links))
+	return links
 }

--- a/models/record_match_run.go
+++ b/models/record_match_run.go
@@ -106,3 +106,19 @@ func (rmr *RecordMatchRun) GetLinks() []Link {
 	sort.Sort(LinkSlice(links))
 	return links
 }
+
+func (rmr *RecordMatchRun) GetWorstLinks(count int) []Link {
+	links := rmr.GetLinks()
+	if count >= len(links) {
+		return links
+	}
+	return links[:count]
+}
+
+func (rmr *RecordMatchRun) GetBestLinks(count int) []Link {
+	links := rmr.GetLinks()
+	if count >= len(links) {
+		return links
+	}
+	return links[len(links)-count : len(links)]
+}

--- a/models/record_match_run_test.go
+++ b/models/record_match_run_test.go
@@ -1,0 +1,43 @@
+package models
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/pebbe/util"
+	. "gopkg.in/check.v1"
+)
+
+type RecordMatchRunSuite struct {
+	Run *RecordMatchRun
+}
+
+var _ = Suite(&RecordMatchRunSuite{})
+
+func (r *RecordMatchRunSuite) SetUpSuite(c *C) {
+	data, err := os.Open("../fixtures/record-match-run-responses.json")
+	util.CheckErr(err)
+	defer data.Close()
+
+	decoder := json.NewDecoder(data)
+	rmr := &RecordMatchRun{}
+	err = decoder.Decode(rmr)
+	util.CheckErr(err)
+	r.Run = rmr
+}
+
+func (r *RecordMatchRunSuite) TestGetLinks(c *C) {
+	links := r.Run.GetLinks()
+	c.Assert(len(links), Equals, 3)
+	firstLink := links[0]
+	c.Assert(firstLink.Score, Equals, 0.51)
+	c.Assert(firstLink.Source, Equals, "http://localhost:3001/Patient/5616b6a11cd462440e001586")
+	c.Assert(firstLink.Target, Equals, "http://localhost:3001/Patient/57335e8465ddb433bd30f0ef")
+	c.Assert(firstLink.Match, Equals, "probable")
+
+	lastLink := links[2]
+	c.Assert(lastLink.Score, Equals, 0.82)
+	c.Assert(lastLink.Source, Equals, "http://localhost:3001/Patient/5616b69a1cd462440e0006ae")
+	c.Assert(lastLink.Target, Equals, "http://localhost:3001/Patient/57335da265ddb433bd30f0ee")
+	c.Assert(lastLink.Match, Equals, "probable")
+}

--- a/server/server_setup.go
+++ b/server/server_setup.go
@@ -90,9 +90,9 @@ func registerRoutes(svr *fhir_svr.FHIRServer) {
 	name := "RecordMatchRun"
 	svr.Engine.GET("/"+name, controller.GetResources)
 	svr.Engine.GET("/"+name+"/:id", controller.GetResource)
-	svr.Engine.POST("/"+name, rc.CreateRecordMatchRunHandler(Database()))
+	svr.Engine.POST("/"+name, rc.CreateRecordMatchRunHandler(Database))
 	svr.Engine.PUT("/"+name+"/:id", controller.UpdateResource)
 	svr.Engine.DELETE("/"+name+"/:id", controller.DeleteResource)
 
-	svr.Engine.GET("/RecordMatchRunMetrics", rc.GetRecordMatchRunMetricsHandler(Database()))
+	svr.Engine.GET("/RecordMatchRunMetrics", rc.GetRecordMatchRunMetricsHandler(Database))
 }

--- a/server/server_setup.go
+++ b/server/server_setup.go
@@ -95,4 +95,6 @@ func registerRoutes(svr *fhir_svr.FHIRServer) {
 	svr.Engine.DELETE("/"+name+"/:id", controller.DeleteResource)
 
 	svr.Engine.GET("/RecordMatchRunMetrics", rc.GetRecordMatchRunMetricsHandler(Database))
+	svr.Engine.GET("/RecordMatchRunLinks/:id", rc.GetRecordMatchRunLinksHandler(Database))
+
 }

--- a/server/server_setup.go
+++ b/server/server_setup.go
@@ -90,9 +90,9 @@ func registerRoutes(svr *fhir_svr.FHIRServer) {
 	name := "RecordMatchRun"
 	svr.Engine.GET("/"+name, controller.GetResources)
 	svr.Engine.GET("/"+name+"/:id", controller.GetResource)
-	svr.Engine.POST("/"+name, controller.CreateRecordMatchRun)
+	svr.Engine.POST("/"+name, rc.CreateRecordMatchRunHandler(Database()))
 	svr.Engine.PUT("/"+name+"/:id", controller.UpdateResource)
 	svr.Engine.DELETE("/"+name+"/:id", controller.DeleteResource)
 
-	svr.Engine.GET("/RecordMatchRunMetrics", controller.GetRecordMatchRunMetrics)
+	svr.Engine.GET("/RecordMatchRunMetrics", rc.GetRecordMatchRunMetricsHandler(Database()))
 }


### PR DESCRIPTION
Provides a service to get just the links for a match job, with the ability to limit the number returned
Refactored the services that deal with RecordMatchRun. I pulled them out of the ResourceController since they are not applicable to any other resources.
