### PR TITLE
Handle redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ line flags must be used:
     -heartOP - The URL of the HEART compliant OpenID Connect Provider
     -heartClientID - The client identifier for this system as registered at the OpenID Connect Provider
 
+Note: The test harness is not able to work with an FHIR server acting as a message broker between
+the test harness and record matching system.  This condition is presumed if the
+test harness receives a redirect from the message broker. When this occurs, the
+test harness persists the record match request in its own database. No issues
+should be encountered when the test harness acts as the message broker.
+
 ## License
 
 Copyright 2016 The MITRE Corporation

--- a/controllers/record_match_run.go
+++ b/controllers/record_match_run.go
@@ -105,16 +105,30 @@ func CreateRecordMatchRunHandler(provider func() *mgo.Database) gin.HandlerFunc 
 				"message":         reqMatchRequest.Message}).Info("About to submit request")
 
 		reqMatchRequest.SubmittedOn = time.Now()
-		// submit the record match request
+
+		// Send the record match request to a FHIR server acting as msg broker.
 		resp, err := ptm_http.Put(svrEndpoint, "application/json+fhir",
 			bytes.NewReader(reqBody))
 		if err != nil {
-			logger.Log.WithFields(
-				logrus.Fields{"method": "CreateRecordMatchRun",
-					"err": err}).Warn("Sending Record Match Request")
-			ctx.AbortWithError(http.StatusInternalServerError, err)
-			return
+			// HACK In this configuration, the test harness only supports itself as the FHIR message broker
+			if resp.StatusCode == 302 {
+				logger.Log.Debug("CreateRecordMatchRun: redirect detected - Infer server is in Heart mode")
+				_, err = ptm_models.PersistFhirResource(provider(), "Bundle", reqMatchRequest.Message)
+				if err != nil {
+					ctx.AbortWithError(http.StatusInternalServerError, err)
+					return
+				}
+			} else {
+				logger.Log.WithFields(
+					logrus.Fields{"method": "CreateRecordMatchRun",
+						"err": err}).Warn("Sending Record Match Request")
+				ctx.AbortWithError(http.StatusInternalServerError, err)
+				return
+			}
 		}
+		logger.Log.WithFields(
+			logrus.Fields{"method": "CreateRecordMatchRun",
+				"status": resp.StatusCode}).Info("Put Response Status")
 
 		// Store status, Sent, with the run object
 		recMatchRun.Status = make([]ptm_models.RecordMatchRunStatusComponent, 1)
@@ -122,6 +136,8 @@ func CreateRecordMatchRunHandler(provider func() *mgo.Database) gin.HandlerFunc 
 		// if a success code was received
 		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 			recMatchRun.Status[0].Message = "Request Sent [" + resp.Status + "]"
+		} else if resp.StatusCode == 302 {
+			recMatchRun.Status[0].Message = "Request Persisted in test harness database"
 		} else {
 			recMatchRun.Status[0].Message = "Error Sending Request to Record Matcher [" + resp.Status + "]"
 		}
@@ -186,10 +202,8 @@ func GetRecordMatchRunMetricsHandler(provider func() *mgo.Database) gin.HandlerF
 				ctx.String(http.StatusNotFound, "Not Found")
 				ctx.Abort()
 				return
-			} else {
-				ctx.AbortWithError(http.StatusBadRequest, err)
-				return
 			}
+			ctx.AbortWithError(http.StatusBadRequest, err)
 		}
 
 		ctx.JSON(http.StatusOK, resources)

--- a/http/client.go
+++ b/http/client.go
@@ -16,9 +16,21 @@ limitations under the License.
 package http
 
 import (
+	"errors"
 	"io"
 	"net/http"
 )
+
+// ErrRedirectAttempt is a custom error to know if a redirect happened
+var ErrRedirectAttempt = errors.New("redirect")
+
+// HTTPClient returns an error when a redirect attempt is detected
+var HTTPClient = &http.Client{CheckRedirect: RedirectError}
+
+// RedirectError returns ErrRedirectAttempt
+func RedirectError(req *http.Request, via []*http.Request) error {
+	return ErrRedirectAttempt
+}
 
 // Put uses net/http DefaultClient to issue a PUT to the specified URL.
 //
@@ -29,10 +41,12 @@ import (
 //
 // To set custom headers, use NewRequest and Client.Do.
 func Put(url string, bodyType string, body io.Reader) (resp *http.Response, err error) {
+
 	req, err := http.NewRequest("PUT", url, body)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", bodyType)
-	return http.DefaultClient.Do(req)
+
+	return HTTPClient.Do(req)
 }


### PR DESCRIPTION
If the test harness receives a redirect from a FHIR server acting as a message broker between the test  harness and record matching system, the test harness will store the request in its local database.
